### PR TITLE
refactor: new vercel monorepo support

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -98,7 +98,6 @@ export async function build ({ files, entrypoint, workPath, config = {}, meta = 
       '--frozen-lockfile',
       '--non-interactive',
       '--production=false',
-      `--modules-folder=${rootDir}/node_modules`,
       `--cache-folder=${yarnCacheDir}`
     ], { ...spawnOpts, env: { ...spawnOpts.env, NODE_ENV: 'development' } })
   } else {
@@ -182,7 +181,6 @@ export async function build ({ files, entrypoint, workPath, config = {}, meta = 
       '--pure-lockfile',
       '--non-interactive',
       '--production=true',
-      `--modules-folder=${rootDir}/node_modules`,
       `--cache-folder=${yarnCacheDir}`
     ], spawnOpts)
   } else {


### PR DESCRIPTION
[Vercel officially supports monorepos](https://vercel.com/blog/monorepos) and can access source files outside the Root Directory (which enables Yarn & Lerna Workspaces). We don't need to set the --modules-folder when using yarn anymore. 

Just enable the "Include source files outside of the Root Directory in the Build Step" option in the Root Directory section within the project settings. 

Vercel projects created after August 27th 2020 23:50 UTC have this option enabled by default.
