### PR TITLE
feat: add internal server for serverMiddleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,25 +111,6 @@ A common use case in Nuxt is to use [`serverMiddleware`][serverMiddleware] put a
     }
     ```
 
-4. Set up `@nuxtjs/axios` to use the base URL from Vercel.
-
-    ```js
-    const baseUrl = process.env.baseUrl || (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined)
-    export default {
-      // ...
-      modules: [
-        ['@nuxtjs/axios', withoutNullishEntries({ baseURL: baseUrl })],
-      ],
-      env: withoutNullishEntries({
-        baseUrl
-      }),
-    }
-
-    function withoutNullishEntries(x) {
-      return Object.fromEntries(Object.entries(x).filter(([k, v]) => v != null))
-    }
-    ```
-
 [serverMiddleware]: https://nuxtjs.org/api/configuration-servermiddleware/
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -78,38 +78,6 @@ See [Deploying two Nuxt apps side-by-side](./examples/side-by-side/README.md) fo
 
 References to original TS files in strings outside of `modules` or `serverMiddleware` may therefore cause unexpected errors.
 
-## Using with `serverMiddleware` and `asyncData`
-
-A common use case in Nuxt is to use [`serverMiddleware`][serverMiddleware] put an API server on the same server as Nuxt. This requires some set up:
-
-1. Set up `serverMiddleware` config in `nuxt.config.js`:
-
-    ```js
-      serverMiddleware: [
-        { path: '/api', handler: '~/api/index.js' },
-      ],
-    ```
-
-   **Note:** This assumes that your API will be served at `/api` and its source code is in `api/index.js` (same as [Nuxt’s documentation][serverMiddleware]).
-
-2. Set up `serverFiles` in `now.json`:
-
-    ```json
-    {
-      "version": 2,
-      "builds": [
-        {
-          "src": "nuxt.config.js",
-          "use": "@nuxtjs/vercel-builder",
-          "config": {
-            "serverFiles": ["api/**"]
-          }
-        }
-      ]
-    }
-    ```
-
-[serverMiddleware]: https://nuxtjs.org/api/configuration-servermiddleware/
 
 ## Configuration
 
@@ -134,6 +102,15 @@ Example:
   ]
 }
 ```
+
+### internalServer
+
+- Type: `Boolean`
+- Default: `false`
+
+If you have defined `serverMiddleware` in your `nuxt.config`, this builder will automatically enable an internal server within the lambda so you can access your own endpoints via `http://localhost:3000`. (This does not affect how you call your endpoints from client-side.)
+
+If you need to enable or disable the internal server manually (for example, if you are adding server middleware via a module), just set `internalServer` within the builder options.
 
 ### `generateStaticRoutes`
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ See [Deploying two Nuxt apps side-by-side](./examples/side-by-side/README.md) fo
 
 References to original TS files in strings outside of `modules` or `serverMiddleware` may therefore cause unexpected errors.
 
-
 ## Configuration
 
 ### `serverFiles`

--- a/README.md
+++ b/README.md
@@ -92,9 +92,7 @@ A common use case in Nuxt is to use [`serverMiddleware`][serverMiddleware] put a
 
    **Note:** This assumes that your API will be served at `/api` and its source code is in `api/index.js` (same as [Nuxt’s documentation][serverMiddleware]).
 
-2. Go to your **Project Settings** &rarr; **Environment Variables** and add an environment variable `VERCEL_URL` to all environments. When you type in the name, Vercel will say that it is a [system environment variable](https://vercel.com/docs/build-step#system-environment-variables) and its value will be automatically populated by the system.
-
-3. Set up `serverFiles` in `now.json`:
+2. Set up `serverFiles` in `now.json`:
 
     ```json
     {

--- a/src/build.ts
+++ b/src/build.ts
@@ -138,7 +138,7 @@ export async function build (opts: BuildOptions & { config: NuxtBuilderConfig })
   const buildDir = nuxtConfigFile.buildDir ? path.relative(entrypointPath, nuxtConfigFile.buildDir) : '.nuxt'
   const srcDir = nuxtConfigFile.srcDir ? path.relative(entrypointPath, nuxtConfigFile.srcDir) : '.'
   const lambdaName = nuxtConfigFile.lambdaName ? nuxtConfigFile.lambdaName : 'index'
-  const usesServerMiddleware = config.internalServer ?? !!nuxtConfigFile.serverMiddleware
+  const usesServerMiddleware = config.internalServer !== undefined ? config.internalServer : !!nuxtConfigFile.serverMiddleware
 
   await exec('nuxt', [
     'build',

--- a/src/build.ts
+++ b/src/build.ts
@@ -24,6 +24,7 @@ interface NuxtBuilderConfig {
   generateStaticRoutes?: boolean
   includeFiles?: string[] | string
   serverFiles?: string[]
+  internalServer?: boolean
 }
 
 export async function build (opts: BuildOptions & { config: NuxtBuilderConfig }): Promise<BuilderOutput> {
@@ -137,6 +138,7 @@ export async function build (opts: BuildOptions & { config: NuxtBuilderConfig })
   const buildDir = nuxtConfigFile.buildDir ? path.relative(entrypointPath, nuxtConfigFile.buildDir) : '.nuxt'
   const srcDir = nuxtConfigFile.srcDir ? path.relative(entrypointPath, nuxtConfigFile.srcDir) : '.'
   const lambdaName = nuxtConfigFile.lambdaName ? nuxtConfigFile.lambdaName : 'index'
+  const usesServerMiddleware = config.internalServer ?? !!nuxtConfigFile.serverMiddleware
 
   await exec('nuxt', [
     'build',
@@ -222,6 +224,7 @@ export async function build (opts: BuildOptions & { config: NuxtBuilderConfig })
   const launcherSrc = (await fs.readFile(launcherPath, 'utf8'))
     .replace(/__NUXT_SUFFIX__/g, nuxtDep.suffix)
     .replace(/__NUXT_CONFIG__/g, './' + nuxtConfigName)
+    .replace(/\/\* __ENABLE_INTERNAL_SERVER__ \*\/ *true/g, String(usesServerMiddleware))
 
   const launcherFiles = {
     'vercel__launcher.js': new FileBlob({ data: launcherSrc }),

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -1,4 +1,4 @@
-import http from 'http'
+import type { RequestListener } from 'http'
 import esmCompiler from 'esm'
 
 const startTime = process.hrtime()
@@ -33,10 +33,10 @@ const readyPromise = nuxt.ready().then(() => {
 })
 
 // Create bridge and start listening
-const { Server } = require('http') as typeof http // eslint-disable-line import/order
+const { Server } = require('http') as typeof import('http') // eslint-disable-line import/order
 const { Bridge } = require('./vercel__bridge.js') as typeof import('@vercel/node-bridge/bridge')
 
-const requestListener: http.RequestListener = async (req, res) => {
+const requestListener: RequestListener = async (req, res) => {
   if (!isReady) {
     await readyPromise
   }
@@ -48,8 +48,11 @@ const server = new Server(requestListener)
 const bridge = new Bridge(server)
 bridge.listen()
 
-// Allow internal calls from Nuxt to endpoints registered as serverMiddleware
-const internalServer = new Server(requestListener)
-internalServer.listen(3000, '127.0.0.1')
+// eslint-disable-next-line
+if (/* __ENABLE_INTERNAL_SERVER__ */true) {
+  // Allow internal calls from Nuxt to endpoints registered as serverMiddleware
+  const internalServer = new Server(requestListener)
+  internalServer.listen(3000, '127.0.0.1')
+}
 
 export const launcher: typeof bridge.launcher = bridge.launcher


### PR DESCRIPTION
Running Nuxt and API on the same server is a common use case.

At first, this is not supported. Quoting @danielroe from https://github.com/nuxt/vercel-builder/issues/332#issuecomment-678660418:

> I suspect you might be trying to connect to your serverMiddleware API on server side, which will not work in a serverless environment.

Later in #341, it was suggested that using `$VERCEL_URL` can work around this issue. I previously filed #373 which adds a docs about this workaround. Although it works, it is quite hacky and is unperformant:

- It requires extra configuration.
- It relies on `$VERCEL_URL` to be able to make Nuxt invoke the API on the same deployment.
- In runtime, this causes 2 separate instances of the Lambda function to launch, doubling the response time (due to waiting for 2 cold boots: one in Nuxt and another in API). This made the serverless function timeout a lot.

Today, I took a quick look at the source code and I discovered a simple fix: Just launch an HTTP server on port 3000 (this happens to be the default port configured by `@nuxtjs/axios`) and problem is solved. Using `@nuxtjs/axios` to call serverMiddleware API on server side “just works” now.

## How to try it out

I published my fork to `npm` so you can `"use": "@dtinth/nuxtjs__vercel-builder@prerelease"` to test it.