### PR TITLE
docs: fixed link to example

### DIFF
--- a/examples/side-by-side/README.md
+++ b/examples/side-by-side/README.md
@@ -4,7 +4,7 @@
 
 The goal of this, is to run multiple Nuxt apps in one Vercel deployment, and allow them to use shared components.
 
-To see this working altogether, check out [a deployable example of two side-by-side apps](./side-by-side-example).
+To see this working altogether, check out [a deployable example of two side-by-side apps](./).
 
 ## Setting up this example.
 


### PR DESCRIPTION
From 
<img width="400" src="https://user-images.githubusercontent.com/6775220/120742960-4b592900-c4f8-11eb-91ce-035870c42d9c.png" />
With current link (https://github.com/nuxt/vercel-builder/blob/main/examples/side-by-side/side-by-side-example)

To:
<img width="400" src="https://user-images.githubusercontent.com/6775220/120743092-9a06c300-c4f8-11eb-9e36-f610e22e6214.png" />

With https://github.com/nuxt/vercel-builder/tree/main/examples/side-by-side