### PR TITLE
feat: allow disabling cache with `NUXT_CACHE_DISABLED` flag

### DIFF
--- a/src/prepare-cache.ts
+++ b/src/prepare-cache.ts
@@ -6,8 +6,12 @@ import { startStep, endStep } from './utils'
 async function prepareCache ({ workPath }: PrepareCacheOptions): Promise<Files> {
   startStep('Collect cache')
 
+  const dirs = process.env.NUXT_CACHE_DISABLED === '1'
+    ? []
+    : ['.nuxt', '.vercel_cache', 'node_modules_dev', 'node_modules_prod']
+
   const cache: Files = {}
-  for (const dir of ['.nuxt', '.vercel_cache', 'node_modules_dev', 'node_modules_prod']) {
+  for (const dir of dirs) {
     const files = await glob(`**/${dir}/**`, workPath)
     consola.info(`${Object.keys(files).length} files collected from ${dir}`)
     Object.assign(cache, files)


### PR DESCRIPTION
The cache directory is caching files with absolute paths causing deployments with multiple [`builds`](https://github.com/nuxt/vercel-builder/blob/77d99669119c0f319675c1a249328ee1ce105ded/examples/basic/vercel.json#L3) to occasionally fail if they complete in a different order than the previous build.

This PR adds a flag to disable caching until the proper fix can be found.