### PR TITLE
feat: add post build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,9 +195,11 @@ Alternatively, you can inline your entire `.npmrc` file in a `NPM_RC` environmen
 
 The newest available Node.js version is automatically selected. If your packages depend on a particular major release Node.js version, you can specify the version in your `package.json` - see [Vercel documentation](https://vercel.com/docs/concepts/functions/serverless-functions/runtimes/node-js#node.js-version).
 
-### `vercel-build` script support
+### `vercel-build`, `post-vercel-build` script support
 
-This builder will run a given [custom build step](https://vercel.com/docs/runtimes#advanced-usage/advanced-node-js-usage/custom-build-step-for-node-js) if you have added a `vercel-build` key under `scripts` in `package.json`.
+This builder will run a given [custom build step](https://vercel.com/docs/concepts/functions/serverless-functions/runtimes/node-js#custom-build-step-for-node.js) if you have added a `vercel-build` or `post-vercel-build` key under `scripts` in `package.json`.
+
+`vercel-build` script will run before nuxt build and `post-vercel-build` will run after then.
 
 ## Deploying additional serverless functions
 

--- a/src/build.ts
+++ b/src/build.ts
@@ -178,6 +178,16 @@ export async function build (opts: BuildOptions & { config: NuxtBuilderConfig })
     ], spawnOpts)
   }
 
+  // ----------------- Post build -----------------
+  const postBuildSteps = ['post-vercel-build', 'post-now-build']
+  for (const step of postBuildSteps) {
+    if (pkg.scripts && Object.keys(pkg.scripts).includes(step)) {
+      startStep(`Post build (${step})`)
+      await runPackageJsonScript(entrypointPath, step, spawnOpts)
+      break
+    }
+  }
+
   // ----------------- Install dependencies -----------------
   startStep('Install dependencies')
 


### PR DESCRIPTION
Hi Nuxtjs Team,

Thank you for the great builder!

One of our commonly required is to send a notification after the main `nuxt build` is successful in Vercel CI.
But the default `vercel-build` script is run before it so I add a `post-vercel-build` script run after that to give more control during the build process.